### PR TITLE
fix: update wasm bundle name for 2.1.81

### DIFF
--- a/config-overrides/index.js
+++ b/config-overrides/index.js
@@ -28,8 +28,8 @@ function stuff(config, env) {
     new CopyWebpackPlugin({
       patterns: [
         {
-          from: `${path.dirname(require.resolve(`@aztec/sdk`))}/barretenberg.wasm`,
-          to: 'barretenberg.wasm',
+          from: `${path.dirname(require.resolve(`@aztec/sdk`))}/aztec-connect.wasm`,
+          to: 'aztec-connect.wasm',
         },
         {
           from: `${path.dirname(require.resolve(`@aztec/sdk`))}/web_worker.js`,


### PR DESCRIPTION
# Description

Update wasm bundling name, result of breaking change introduced in @aztec/sdk 2.1.81
The bundle is now named `aztec-connect.wasm` rather than `barretenberg.wasm`